### PR TITLE
Acl 11 travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ language: java
 script:
   - ./make.sh clean
   - ./make.sh compile
+
+notifications:
+  slack: microlib:LMRLKmZEldpHe2FQv6Pszuzu

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+
+script:
+  - ./make.sh clean
+  - ./make.sh compile

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# ACL info
+# ACL
+
+[![Build Status](https://travis-ci.org/microlib/acl.svg?branch=master)](https://travis-ci.org/microlib/acl)
 
 ## Environment
 


### PR DESCRIPTION
Title: Travis integration

Motivation: 
We need a basic Travis integration so as to be able to run our tests and make sure the code is compiling correctly

Resolution:
Created a basic Travis integration. It doesn't do anything at the moment other than just calling the `clean` and `compile` commands of the `make.sh`. This will be extended when we have our unit tests and anything else we may want to run on Travis.

Ticket:
#11 
